### PR TITLE
add benchpress tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ The content is a JSON array with 14 fields.
 - Angular v2.0.0-alpha25
 - ReactJS 0.13.0
 
+### Running the benchmarks
+
+1. `$(npm bin)/webdriver-manager install`
+2. `$(npm bin)/protractor protractor.conf.js`
+
 TODO
 - Aurelia
 - raw (direct DOM manipulation)

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   "author": "Alin Capitanescu",
   "license": "MIT",
   "dependencies": {
+    "benchpress": "^2.0.0-alpha.26",
     "bootstrap": "^3.3.4",
-    "http-server": "^0.8.0"
+    "http-server": "^0.8.0",
+    "protractor": "^2.1.0"
   },
   "devDependencies": {
     "json-schema-faker": "^0.1.10",

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -1,0 +1,33 @@
+var httpServer = require('http-server');
+
+exports.config = {
+  directConnect: true,
+
+  capabilities: {
+    browserName: 'chrome',
+    chromeOptions: {
+      //Important for benchpress to get timeline data from the browser
+      'args': ['--js-flags=--expose-gc'],
+      'perfLoggingPrefs': {
+        'traceCategories': 'v8,blink.console,disabled-by-default-devtools.timeline'
+      }
+    },
+    loggingPrefs: {
+      performance: 'ALL'
+    }
+  },
+
+  specs: ['table_benchmark.spec.js'],
+  framework: 'jasmine2',
+
+  beforeLaunch: function () {
+    httpServer.createServer({
+      showDir: false
+    }).listen('8080', 'localhost');
+  },
+
+  jasmineNodeOpts: {
+    showColors: true,
+    defaultTimeoutInterval: 3000000
+  },
+};

--- a/table_benchmark.spec.js
+++ b/table_benchmark.spec.js
@@ -1,0 +1,82 @@
+var benchpress = require('benchpress');
+var runner = new benchpress.Runner([
+  //use protractor as Webdriver client
+  benchpress.SeleniumWebDriverAdapter.PROTRACTOR_BINDINGS,
+  //use RegressionSlopeValidator to validate samples
+  benchpress.Validator.bindTo(benchpress.RegressionSlopeValidator),
+  //use 10 samples to calculate slope regression
+  benchpress.bind(benchpress.RegressionSlopeValidator.SAMPLE_SIZE).toValue(10),
+  //use the script metric to calculate slope regression
+  benchpress.bind(benchpress.RegressionSlopeValidator.METRIC).toValue('scriptTime'),
+  benchpress.bind(benchpress.Options.FORCE_GC).toValue(true)
+]);
+
+var pages = [
+  {
+    name: 'ng1.2.20',
+    url: 'http://localhost:8080/angular1/index.html',
+  },
+  {
+    name: 'ng1.3.9',
+    url: 'http://localhost:8080/angular1/index2.html',
+  },
+  {
+    name: 'ng1.4.0',
+    url: 'http://localhost:8080/angular1/index3.html',
+  },
+  {
+    name: 'ng2.0.0-alpha.26',
+    url: 'http://localhost:8080/angular2/dist/index.html',
+    ignoreSynchronization: true,
+  },
+  {
+    name: 'React0.13.0',
+    url: 'http://localhost:8080/reactjs/index.html',
+  },
+];
+
+var buttons = [
+  {
+    name: '500 records',
+    selector: 'a[role="button"].btn-success:nth-child(1)',
+  },
+  {
+    name: '1500 records',
+    selector: 'a[role="button"].btn-success:nth-child(2)',
+  },
+  {
+    name: '2500 records',
+    selector: 'a[role="button"].btn-success:nth-child(3)',
+  },
+  {
+    name: '5000 records',
+    selector: 'a[role="button"].btn-success:nth-child(4)',
+  },
+];
+
+
+describe('angularjs', function() {
+
+  pages.forEach(function(page) {
+    buttons.forEach(function(button) {
+      it('should log ' + page.name + ' stats for ' + button.name, function(done) {
+        browser.ignoreSynchronization = true;
+        runner.sample({
+          id: page.name + '-' + button.name + '-table',
+          prepare: function() {
+            browser.get(page.url);
+            // wait for the page to be loaded
+            browser.sleep(1000);
+          },
+          execute: function() {
+            $(button.selector).click();
+            // wait at least until the table has been destroyed and recreated.
+            // Note that this wait time won't show up in the benchmark results,
+            // as benchpress reads out the dev tools data.
+            browser.sleep(3000);
+          }
+        }).then(done, done.fail);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This adds the [benchpress](https://github.com/angular/angular/blob/master/modules/benchpress/docs/index.md) to the setup, which allows to capture the data from the chrome timeline during a webdriver test.

Run the tests as described in the readme, and you should see something like this printed to the console:

```
BENCHMARK ng2.0.0-alpha.26:5000 records-table
Description:
- forceGc: true
- regressionSlopeMetric: scriptTime
- sampleSize: 2
- userAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.30 Safari/537.36
Metrics:
- forcedGcAmount: forced gc amount in kbytes
- forcedGcTime: forced gc time in ms
- gcAmount: gc amount in kbytes
- gcTime: gc time in ms
- majorGcTime: time of major gcs in ms
- pureScriptTime: script execution time in ms, without gc nor render
- renderTime: render time in ms
- scriptTime: script execution time in ms, including gc and render

    forcedGcAmount |       forcedGcTime |           gcAmount |             gcTime |        majorGcTime |     pureScriptTime |         renderTime |         scriptTime
------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------
           3106.60 |              55.74 |            9205.46 |              96.28 |              14.29 |             698.16 |            2448.66 |             793.97
           3175.02 |              55.16 |            8954.63 |              95.18 |              13.39 |             706.39 |            2347.73 |             801.58
================== | ================== | ================== | ================== | ================== | ================== | ================== | ==================
       3140.81+-1% |          55.45+-0% |        9080.05+-1% |          95.73+-0% |          13.84+-3% |         702.27+-0% |        2398.19+-2% |         797.78+-0%
```
